### PR TITLE
fixing typos in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Users can find the pre-compiled file `STTM.jar` and source codes in folders `src
 !!! note "Note"
     If users train these models based word embeddings, users need to download the Pre-trained word embeddings. In the package, the code is based on [Global Vectors](https://nlp.stanford.edu/projects/glove/).
 
-    $ java [-Xmx1G] -jar jar/STTM.jar –model <GPUDMM or GPU-PDMM or LFDMM or LFLDA> -corpus <Input_corpus_file_path> -vectors <Input_Word2vec_file_Path> [-ntopics <int>] [-alpha <double>] [-beta <double>] [-niters <int>] [-twords <int>] [-name <String>] [-sstep <int>]
+    $ java [-Xmx1G] -jar jar/STTM.jar –model <GPUDMM or GPU_PDMM or LFDMM or LFLDA> -corpus <Input_corpus_file_path> -vectors <Input_Word2vec_file_Path> [-ntopics <int>] [-alpha <double>] [-beta <double>] [-niters <int>] [-twords <int>] [-name <String>] [-sstep <int>]
 
 where parameters in [ ] are optional. More parameters in different methods are shown in "src/utility/CmdArgs"
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Challenge (Everingham et al., 2010). PAS includes twenty categories of images an
 * Topic coherence: Computing topic coherence, additional dataset (Wikipedia) as a single
 meta-document is needed to score word pairs using term cooccurrence in the paper (Automatic Evaluation of Topic Coherence). Here, we calculate the pointwise mutual
 information (PMI) of each word pair, estimated from the entire corpus of over one million English Wikipedia articles. Using a sliding window of 10-
-words to identify co-occurrence, we computed the PMI of all a given word pair. The wikipedia can downloaded [Here](https://dumps.wikimedia.org/enwiki/20180720/). Then, we can transfer the dataset from html to text using the [code](https://github.com/qiang2100/STTM/blob/master/process_wiki.py) through executing "python process_wiki.py enwiki-latest-pages-articles.xml.bz2 wiki.en.text". Finally, due to the large size, we only choose a part of them.
+words to identify co-occurrence, we computed the PMI of all a given word pair. The wikipedia can downloaded [Here](https://dumps.wikimedia.org/enwiki/). Then, we can transfer the dataset from html to text using the [code](https://github.com/qiang2100/STTM/blob/master/process_wiki.py) through executing "python process_wiki.py enwiki-latest-pages-articles.xml.bz2 wiki.en.text". Finally, due to the large size, we only choose a part of them.
 
 * Cluster Evaluation (Purity and NMI): By choosing the maximum of topic probability for each text, we can get the cluster label for each text. Then, we can compare the cluster label and the golden label using metric Purity and NMI.
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Users can find the pre-compiled file `STTM.jar` and source codes in folders `src
 
 **Now, we can train the algorithms in STTM tool by executing:**
 
-	$ java [-Xmx1G] -jar jar/STTM.jar –model <LDA or BTM or PTM or SATM or DMM or WATM> -corpus <Input_corpus_file_path> [-ntopics <int>] [-alpha <double>] [-beta <double>] [-niters <int>] [-twords <int>] [-name <String>] [-sstep <int>]
+	$ java [-Xmx1G] -jar jar/STTM.jar –model <LDA or BTM or PTM or SATM or DMM or WNTM> -corpus <Input_corpus_file_path> [-ntopics <int>] [-alpha <double>] [-beta <double>] [-niters <int>] [-twords <int>] [-name <String>] [-sstep <int>]
 
 !!! note "Note"
     If users train these models based word embeddings, users need to download the Pre-trained word embeddings. In the package, the code is based on [Global Vectors](https://nlp.stanford.edu/projects/glove/).


### PR DESCRIPTION
There were just a few typos in the readme in the CLI examples.